### PR TITLE
bump Go version to 1.24 in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.17
+          go-version: 1.24
 
       - name: Install Helm
         uses: azure/setup-helm@v1


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 更新了发布流程所用的 Go 版本，从 1.17 升级至 1.24。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->