### PR TITLE
add missing library copy for lxcfs in Dockerfile

### DIFF
--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -27,7 +27,7 @@ RUN wget https://linuxcontainers.org/downloads/lxcfs/lxcfs-$LXCFS.tar.gz && \
 FROM gcr.io/distroless/base@sha256:d8244d4756b5dc43f2c198bf4e37e6f8a017f13fdd7f6f64ec7ac7228d3b191e
 
 COPY --from=builder /usr/bin/lxcfs /usr/bin/lxcfs
-COPY --from=builder /lib/x86_6/usr/lib/x86_64-linux-gnu/lxcfs/liblxcfs.so /usr/lib/x86_64-linux-gnu/lxcfs/liblxcfs.so
+COPY --from=builder /usr/lib/x86_64-linux-gnu/lxcfs/liblxcfs.so /usr/lib/x86_64-linux-gnu/lxcfs/liblxcfs.so
 COPY --from=builder /lib/x86_64-linux-gnu/libdl.so.2 /lib/x86_64-linux-gnu/libdl.so.2
 COPY --from=builder /lib/x86_64-linux-gnu/libfuse.so.2 /lib/x86_64-linux-gnu/libfuse.so.2
 COPY --from=builder /lib/x86_64-linux-gnu/libgcc_s.so.1 /lib/x86_64-linux-gnu/libgcc_s.so.1

--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -27,7 +27,7 @@ RUN wget https://linuxcontainers.org/downloads/lxcfs/lxcfs-$LXCFS.tar.gz && \
 FROM gcr.io/distroless/base@sha256:d8244d4756b5dc43f2c198bf4e37e6f8a017f13fdd7f6f64ec7ac7228d3b191e
 
 COPY --from=builder /usr/bin/lxcfs /usr/bin/lxcfs
-COPY --from=builder /lib/x86_64-linux-gnu/liblxcfs.so /lib/x86_64-linux-gnu/liblxcfs.so
+COPY --from=builder /lib/x86_6/usr/lib/x86_64-linux-gnu/lxcfs/liblxcfs.so /usr/lib/x86_64-linux-gnu/lxcfs/liblxcfs.so
 COPY --from=builder /lib/x86_64-linux-gnu/libdl.so.2 /lib/x86_64-linux-gnu/libdl.so.2
 COPY --from=builder /lib/x86_64-linux-gnu/libfuse.so.2 /lib/x86_64-linux-gnu/libfuse.so.2
 COPY --from=builder /lib/x86_64-linux-gnu/libgcc_s.so.1 /lib/x86_64-linux-gnu/libgcc_s.so.1

--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -27,6 +27,7 @@ RUN wget https://linuxcontainers.org/downloads/lxcfs/lxcfs-$LXCFS.tar.gz && \
 FROM gcr.io/distroless/base@sha256:d8244d4756b5dc43f2c198bf4e37e6f8a017f13fdd7f6f64ec7ac7228d3b191e
 
 COPY --from=builder /usr/bin/lxcfs /usr/bin/lxcfs
+COPY --from=builder /lib/x86_64-linux-gnu/liblxcfs.so /lib/x86_64-linux-gnu/liblxcfs.so
 COPY --from=builder /lib/x86_64-linux-gnu/libdl.so.2 /lib/x86_64-linux-gnu/libdl.so.2
 COPY --from=builder /lib/x86_64-linux-gnu/libfuse.so.2 /lib/x86_64-linux-gnu/libfuse.so.2
 COPY --from=builder /lib/x86_64-linux-gnu/libgcc_s.so.1 /lib/x86_64-linux-gnu/libgcc_s.so.1


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * 更新了 agent 镜像的 Dockerfile，新增了对共享库文件 liblxcfs.so 的支持。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->