### PR TITLE
chore: update Helm setup version in release workflow and add ci-generate workflow

### DIFF
--- a/.github/workflows/ci-generate.yaml
+++ b/.github/workflows/ci-generate.yaml
@@ -43,4 +43,4 @@ jobs:
 
       - name: Generate Helm
         run: |
-          APP_VERSION=master make generate
+          APP_VERSION=v1.0.0 make generate

--- a/.github/workflows/ci-generate.yaml
+++ b/.github/workflows/ci-generate.yaml
@@ -1,0 +1,46 @@
+name: Generate 
+
+on:
+  pull_request:
+    branches:
+      - main
+      - master
+  push:
+    branches:
+      - main
+      - "image/**"
+      - "*image"
+      - "image*"
+    tags:
+      - 'v*'
+    paths-ignore:
+      - .github/workflows/ci.yml
+      - .github/workflows/lock.yml
+      - ".github/ISSUE_TEMPLATE/**"
+      - "docs/**"
+      - "hack/**"
+      - "**.md"
+      - ".gitignore"
+      - "Makefile"
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.24
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4.3.0
+
+      - name: Generate Helm
+        run: |
+          APP_VERSION=master make generate

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,9 +23,8 @@ jobs:
           go-version: 1.24
 
       - name: Install Helm
-        uses: azure/setup-helm@v1
-        with:
-          version: v3.6.0
+        uses: azure/setup-helm@v4.3.0 
+
       - name: Generate Helm
         run: |
           APP_VERSION=${{github.event.inputs.version}} make generate


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **杂项**
  * 新增了一个名为“Generate”的 GitHub Actions 工作流，用于在特定分支和标签上自动执行生成任务。
  * 更新了发布流程中的 Helm 安装步骤，升级了 Helm 安装 Action 的版本，并简化了相关配置。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->