### PR TITLE
fix(lxcfs): update mount path to /var/lib/lxc/lxcfs

### DIFF
--- a/charts/lxcfs-on-kubernetes/README.md
+++ b/charts/lxcfs-on-kubernetes/README.md
@@ -33,7 +33,7 @@ Kubernetes: `>= 1.16.0-0`
 | logLevel | int | `4` | Set the verbosity of controller. Range of 0 - 6 with 6 being the most verbose. Info level is 4. |
 | lxcfs.args | list | `["-l","--enable-cfs","--enable-pidfd"]` | Adjusting the boot parameters of lxcfs |
 | lxcfs.matchLabels | object | `{"mount-lxcfs":"enabled"}` | For namespaces that match the labes, the Pods under it will mount lxcfs. |
-| lxcfs.mountPath | string | `"/var/lib/lxcfs"` | Specify the mount path of lxcfs on the host |
+| lxcfs.mountPath | string | `"/var/lib/lxc/lxcfs"` | Specify the mount path of lxcfs on the host |
 | lxcfs.podAnnotations | object | `{}` | Additional annotations to add to the agent Pods |
 | lxcfs.resources | object | `{"limits":{"cpu":"500m","memory":"300Mi"},"requests":{"cpu":"300m","memory":"200M"}}` | Expects input structure as per specification <https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core> |
 | lxcfs.useDaemonset | bool | `true` | Installing lxcfs with daemonset |

--- a/charts/lxcfs-on-kubernetes/values.yaml
+++ b/charts/lxcfs-on-kubernetes/values.yaml
@@ -72,7 +72,7 @@ lxcfs:
   # lxcfs.useDaemonset -- Installing lxcfs with daemonset
   useDaemonset: true
   # lxcfs.mountPath -- Specify the mount path of lxcfs on the host
-  mountPath: /var/lib/lxcfs
+  mountPath: /var/lib/lxc/lxcfs
   # lxcfs.resources -- Expects input structure as per specification <https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core>
   resources:
     limits:

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -49,7 +49,7 @@ func main() {
 		leaderElection          = flag.Bool("leader-election", false, "LeaderElection determines whether or not to use leader election when starting the manager.")
 		leaderElectionNamespace = flag.String("leader-election-namespace", "default", "The leader election namespace.")
 		leaderElectionID        = flag.String("leader-election-id", "lxcfs-on-kubernetes-leader-election", "The leader election id.")
-		lxcfsPath               = flag.String("lxcfs-path", "/var/lib/lxcfs", "Path for lxcfs mounts.")
+		lxcfsPath               = flag.String("lxcfs-path", "/var/lib/lxc/lxcfs", "Path for lxcfs mounts.")
 	)
 
 	// set logging

--- a/config/default/daemonset_patch.yaml
+++ b/config/default/daemonset_patch.yaml
@@ -12,13 +12,13 @@ spec:
       containers:
         - name: agent
           args:
-            - "/var/lib/lxcfs"
+            - "/var/lib/lxc/lxcfs"
           volumeMounts:
             - name: lxcfs
-              mountPath: /var/lib/lxcfs
+              mountPath: /var/lib/lxc/lxcfs
               mountPropagation: Bidirectional
       volumes:
         - name: lxcfs
           hostPath:
-            path: /var/lib/lxcfs
+            path: /var/lib/lxc/lxcfs
             type: DirectoryOrCreate

--- a/config/default/deployment_patch.yaml
+++ b/config/default/deployment_patch.yaml
@@ -12,4 +12,4 @@ spec:
       containers:
         - name: manager
           args:
-            - --lxcfs-path=/var/lib/lxcfs
+            - --lxcfs-path=/var/lib/lxc/lxcfs

--- a/config/manager/daemonset_patch.yaml
+++ b/config/manager/daemonset_patch.yaml
@@ -15,13 +15,13 @@ spec:
       containers:
         - name: agent
           args:
-            - "/var/lib/lxcfs"
+            - "/var/lib/lxc/lxcfs"
           volumeMounts:
             - name: lxcfs
-              mountPath: /var/lib/lxcfs
+              mountPath: /var/lib/lxc/lxcfs
               mountPropagation: Bidirectional
       volumes:
         - name: lxcfs
           hostPath:
-            path: /var/lib/lxcfs
+            path: /var/lib/lxc/lxcfs
             type: DirectoryOrCreate

--- a/config/manager/deployment_patch.yaml
+++ b/config/manager/deployment_patch.yaml
@@ -12,4 +12,4 @@ spec:
       containers:
         - name: manager
           args:
-            - --lxcfs-path=/var/lib/lxcfs
+            - --lxcfs-path=/var/lib/lxc/lxcfs

--- a/pkg/admission/mutate.go
+++ b/pkg/admission/mutate.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -119,7 +120,7 @@ func (m *mutate) ensureVolumeMount(volumeMounts []corev1.VolumeMount) []corev1.V
 		"lxcfs-proc-loadavg":                  "/proc/loadavg",
 		"lxcfs-sys-devices-system-cpu":        "/sys/devices/system/cpu",
 		"lxcfs-sys-devices-system-cpu-online": "/sys/devices/system/cpu/online",
-		"lxcfs-root":                          m.mutatePath,
+		"lxcfs-root-parent-dir":               filepath.Dir(m.mutatePath),
 	}
 	for _, v := range volumeMounts {
 		if _, ok := mounts[v.Name]; !ok {
@@ -195,9 +196,9 @@ func (m *mutate) ensureVolume(vs []corev1.Volume) []corev1.Volume {
 				Path: m.mutatePath + "sys/devices/system/cpu/online",
 			},
 		},
-		"lxcfs-root": {
+		"lxcfs-root-parent-dir": {
 			HostPath: &corev1.HostPathVolumeSource{
-				Path: m.mutatePath,
+				Path: filepath.Dir(m.mutatePath),
 			},
 		},
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **变更**
  * 默认的 lxcfs 挂载路径由 /var/lib/lxcfs 调整为 /var/lib/lxc/lxcfs，涉及 Helm Chart、配置文件、命令行参数及相关文档。
  * DaemonSet 和 Deployment 配置中的 lxcfs 路径已同步更新至新目录。
  * Admission 控制器相关的挂载目录由原路径调整为其父目录，提升路径一致性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->