### PR TITLE
refactor(lxcfs): update lxcfs mount path to /var/lib/lxcfs-on-k8s/lxcfs

### DIFF
--- a/charts/lxcfs-on-kubernetes/README.md
+++ b/charts/lxcfs-on-kubernetes/README.md
@@ -33,7 +33,7 @@ Kubernetes: `>= 1.16.0-0`
 | logLevel | int | `4` | Set the verbosity of controller. Range of 0 - 6 with 6 being the most verbose. Info level is 4. |
 | lxcfs.args | list | `["-l","--enable-cfs","--enable-pidfd"]` | Adjusting the boot parameters of lxcfs |
 | lxcfs.matchLabels | object | `{"mount-lxcfs":"enabled"}` | For namespaces that match the labes, the Pods under it will mount lxcfs. |
-| lxcfs.mountPath | string | `"/var/lib/lxc/lxcfs"` | Specify the mount path of lxcfs on the host |
+| lxcfs.mountPath | string | `"/var/lib/lxcfs-on-k8s/lxcfs"` | Specify the mount path of lxcfs on the host |
 | lxcfs.podAnnotations | object | `{}` | Additional annotations to add to the agent Pods |
 | lxcfs.resources | object | `{"limits":{"cpu":"500m","memory":"300Mi"},"requests":{"cpu":"300m","memory":"200M"}}` | Expects input structure as per specification <https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core> |
 | lxcfs.useDaemonset | bool | `true` | Installing lxcfs with daemonset |

--- a/charts/lxcfs-on-kubernetes/values.yaml
+++ b/charts/lxcfs-on-kubernetes/values.yaml
@@ -72,7 +72,7 @@ lxcfs:
   # lxcfs.useDaemonset -- Installing lxcfs with daemonset
   useDaemonset: true
   # lxcfs.mountPath -- Specify the mount path of lxcfs on the host
-  mountPath: /var/lib/lxc/lxcfs
+  mountPath: /var/lib/lxcfs-on-k8s/lxcfs
   # lxcfs.resources -- Expects input structure as per specification <https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core>
   resources:
     limits:

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -50,7 +50,7 @@ func main() {
 		leaderElection          = flag.Bool("leader-election", false, "LeaderElection determines whether or not to use leader election when starting the manager.")
 		leaderElectionNamespace = flag.String("leader-election-namespace", "default", "The leader election namespace.")
 		leaderElectionID        = flag.String("leader-election-id", "lxcfs-on-kubernetes-leader-election", "The leader election id.")
-		lxcfsPath               = flag.String("lxcfs-path", "/var/lib/lxc/lxcfs", "Path for lxcfs mounts.")
+		lxcfsPath               = flag.String("lxcfs-path", "/var/lib/lxcfs-on-k8s/lxcfs", "Path for lxcfs mounts.")
 	)
 
 	// set logging

--- a/config/default/daemonset_patch.yaml
+++ b/config/default/daemonset_patch.yaml
@@ -12,13 +12,13 @@ spec:
       containers:
         - name: agent
           args:
-            - "/var/lib/lxc/lxcfs"
+            - "/var/lib/lxcfs-on-k8s/lxcfs"
           volumeMounts:
             - name: lxcfs
-              mountPath: /var/lib/lxc/lxcfs
+              mountPath: /var/lib/lxcfs-on-k8s/lxcfs
               mountPropagation: Bidirectional
       volumes:
         - name: lxcfs
           hostPath:
-            path: /var/lib/lxc/lxcfs
+            path: /var/lib/lxcfs-on-k8s/lxcfs
             type: DirectoryOrCreate

--- a/config/default/deployment_patch.yaml
+++ b/config/default/deployment_patch.yaml
@@ -12,4 +12,4 @@ spec:
       containers:
         - name: manager
           args:
-            - --lxcfs-path=/var/lib/lxc/lxcfs
+            - --lxcfs-path=/var/lib/lxcfs-on-k8s/lxcfs

--- a/config/manager/daemonset_patch.yaml
+++ b/config/manager/daemonset_patch.yaml
@@ -15,13 +15,13 @@ spec:
       containers:
         - name: agent
           args:
-            - "/var/lib/lxc/lxcfs"
+            - "/var/lib/lxcfs-on-k8s/lxcfs"
           volumeMounts:
             - name: lxcfs
-              mountPath: /var/lib/lxc/lxcfs
+              mountPath: /var/lib/lxcfs-on-k8s/lxcfs
               mountPropagation: Bidirectional
       volumes:
         - name: lxcfs
           hostPath:
-            path: /var/lib/lxc/lxcfs
+            path: /var/lib/lxcfs-on-k8s/lxcfs
             type: DirectoryOrCreate

--- a/config/manager/deployment_patch.yaml
+++ b/config/manager/deployment_patch.yaml
@@ -12,4 +12,4 @@ spec:
       containers:
         - name: manager
           args:
-            - --lxcfs-path=/var/lib/lxc/lxcfs
+            - --lxcfs-path=/var/lib/lxcfs-on-k8s/lxcfs

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -6,9 +6,13 @@ import (
 	"strings"
 )
 
+const (
+	defaultLxcfsParentDir = "lxcfs-on-k8s"
+)
+
 func EnsureLxcfsParentDir(path string) error {
 	lxcDir := filepath.Dir(strings.TrimRight(path, "/"))
-	if !strings.HasSuffix(lxcDir, "lxc") {
+	if !strings.HasSuffix(lxcDir, defaultLxcfsParentDir) {
 		return fmt.Errorf("lxcfs path %s is not valid, it's parent directory should be 'lxc'", path)
 	}
 	return nil

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -13,7 +13,7 @@ const (
 func EnsureLxcfsParentDir(path string) error {
 	lxcDir := filepath.Dir(strings.TrimRight(path, "/"))
 	if !strings.HasSuffix(lxcDir, defaultLxcfsParentDir) {
-		return fmt.Errorf("lxcfs path %s is not valid, it's parent directory should be 'lxc'", path)
+		return fmt.Errorf("lxcfs path %s is not valid, it's parent directory should be '%s'", path, defaultLxcfsParentDir)
 	}
 	return nil
 }

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -12,12 +12,12 @@ func TestEnsureLxcfsParentDir(t *testing.T) {
 	}{
 		{
 			name:    "valid path with trailing slash",
-			path:    "/var/lib/lxc/test/",
+			path:    "/var/lib/lxcfs-on-k8s/test/",
 			wantErr: false,
 		},
 		{
 			name:    "valid path without trailing slash",
-			path:    "/var/lib/lxc/test",
+			path:    "/var/lib/lxcfs-on-k8s/test",
 			wantErr: false,
 		},
 		{
@@ -32,12 +32,12 @@ func TestEnsureLxcfsParentDir(t *testing.T) {
 		},
 		{
 			name:    "parent directory is lxc at root",
-			path:    "/lxc/test",
+			path:    "/lxcfs-on-k8s/test",
 			wantErr: false,
 		},
 		{
-			name:    "path is just /lxc",
-			path:    "/lxc",
+			name:    "path is just /lxcfs-on-k8s",
+			path:    "/lxcfs-on-k8s",
 			wantErr: true,
 		},
 		{
@@ -47,7 +47,7 @@ func TestEnsureLxcfsParentDir(t *testing.T) {
 		},
 		{
 			name:    "path with multiple trailing slashes",
-			path:    "/var/lib/lxc/test///",
+			path:    "/var/lib/lxcfs-on-k8s/test///",
 			wantErr: false,
 		},
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **变更说明**
  * 默认的 lxcfs 挂载路径由 `/var/lib/lxc/lxcfs` 更新为 `/var/lib/lxcfs-on-k8s/lxcfs`，涉及 Helm chart 配置、部署和 DaemonSet 配置等相关文档与参数。
  * 相关文档与配置文件已同步更新，确保新路径在各组件中一致生效。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->