### PR TITLE
feat(lxcfs): add postStart lifecycle and mount additional volumes

### DIFF
--- a/charts/lxcfs-on-kubernetes/templates/daemonset.yaml
+++ b/charts/lxcfs-on-kubernetes/templates/daemonset.yaml
@@ -16,14 +16,26 @@ spec:
     spec:
       containers:
       - args: {{- include "chart.lxcfs.args" . | nindent 8 }}
-        image: {{.Values.image.agent}}
+        image: {{ .Values.image.agent }}
+        lifecycle:
+          postStart:
+            exec:
+              command:
+                - sh
+                - -c
+                - "lxcfs-remount.sh {{ trimSuffix "/" .Values.lxcfs.mountPath }} || true"
         imagePullPolicy: {{ .Values.pullPolicy | quote }}
         name: agent
         resources: {{- toYaml .Values.lxcfs.resources | nindent 10 }}
         securityContext:
           privileged: true
         volumeMounts:
-        - mountPath: {{.Values.lxcfs.mountPath}}
+        - name: cri-socket
+          mountPath: {{ .Values.lxcfs.configMaps.crictlConfig.endpoint }}
+        - name: crictl-config
+          mountPath: /etc/crictl.yaml
+          subPath: crictl.yaml
+        - mountPath: {{ .Values.lxcfs.mountPath }}
           mountPropagation: Bidirectional
           name: lxcfs
         - mountPath: /sys/fs/cgroup
@@ -31,10 +43,17 @@ spec:
       hostPID: true
       volumes:
       - hostPath:
-          path: {{.Values.lxcfs.mountPath}}
+          path: {{ .Values.lxcfs.mountPath }}
           type: DirectoryOrCreate
         name: lxcfs
       - hostPath:
           path: /sys/fs/cgroup
         name: cgroup
+      - name: cri-socket
+        hostPath:
+          path: {{ .Values.lxcfs.configMaps.crictlConfig.endpoint }}
+          type: Socket
+      - name: crictl-config
+        configMap:
+          name: lxcfs-crictl-config
 {{- end -}}

--- a/charts/lxcfs-on-kubernetes/templates/lxcfs-crictl-config.yaml
+++ b/charts/lxcfs-on-kubernetes/templates/lxcfs-crictl-config.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: lxcfs-crictl-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+data:
+  crictl.yaml: |
+    runtime-endpoint: unix://{{ .Values.lxcfs.configMaps.crictlConfig.endpoint }}
+    image-endpoint: unix://{{ .Values.lxcfs.configMaps.crictlConfig.endpoint }}
+    timeout: 10
+    debug: false

--- a/charts/lxcfs-on-kubernetes/values.yaml
+++ b/charts/lxcfs-on-kubernetes/values.yaml
@@ -69,6 +69,11 @@ affinity: {}
 podAnnotations: {}
 
 lxcfs:
+  # lxcfs.configMaps -- ConfigMaps to be created for lxcfs
+  configMaps:
+    crictlConfig:
+      # crictlConfig.endpoint -- The endpoint of the CRI runtime
+      endpoint: /run/containerd/containerd.sock
   # lxcfs.useDaemonset -- Installing lxcfs with daemonset
   useDaemonset: true
   # lxcfs.mountPath -- Specify the mount path of lxcfs on the host


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 增加了对 crictl 配置的支持，可通过新的 ConfigMap 进行自定义。
  * DaemonSet 容器新增挂载 cri socket 及 crictl 配置文件的功能。
  * 配置文件中新增 crictl socket 路径参数，支持自定义运行时端点。

* **其他**
  * 优化了部分模板格式和挂载声明的一致性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->