### PR TITLE
build(deps): bump Go version from 1.24.4 to 1.25

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM --platform=$BUILDPLATFORM golang:1.24.4 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.25 AS builder
 
 SHELL ["/bin/bash", "-euxo", "pipefail", "-c"]
 
@@ -28,10 +28,10 @@ ARG UPX_VERSION=5.0.1
 RUN BUILDARCH="${BUILDPLATFORM##*/}"; \
     UPX_URL="https://github.com/upx/upx/releases/download/v${UPX_VERSION}/upx-${UPX_VERSION}-${BUILDARCH}_linux.tar.xz"; \
     if wget -q "${UPX_URL}" -O /tmp/upx.tar.xz; then \
-        tar -xJvf /tmp/upx.tar.xz -C /usr/bin --strip-components=1 "upx-${UPX_VERSION}-${BUILDARCH}_linux/upx"; \
-        rm -f /tmp/upx.tar.xz; \
+    tar -xJvf /tmp/upx.tar.xz -C /usr/bin --strip-components=1 "upx-${UPX_VERSION}-${BUILDARCH}_linux/upx"; \
+    rm -f /tmp/upx.tar.xz; \
     else \
-        echo "UPX not available for BUILDARCH=${BUILDARCH}; skipping compression"; \
+    echo "UPX not available for BUILDARCH=${BUILDARCH}; skipping compression"; \
     fi
 
 WORKDIR /workspace
@@ -50,9 +50,9 @@ RUN CGO_ENABLED="${CGO_ENABLED}" GOOS="${TARGETOS}" GOARCH="${TARGETARCH}" \
 
 RUN BUILDARCH="${BUILDPLATFORM##*/}"; \
     if command -v upx >/dev/null 2>&1 && [ "${TARGETARCH}" = "${BUILDARCH}" ]; then \
-        upx -9 manager; \
+    upx -9 manager; \
     else \
-        echo "Skipping UPX (upx missing or cross-compile TARGETARCH=${TARGETARCH} BUILDARCH=${BUILDARCH})"; \
+    echo "Skipping UPX (upx missing or cross-compile TARGETARCH=${TARGETARCH} BUILDARCH=${BUILDARCH})"; \
     fi
 
 # alpine:3.22.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cndoit18/lxcfs-on-kubernetes
 
-go 1.24.4
+go 1.25
 
 require (
 	github.com/spf13/pflag v1.0.10


### PR DESCRIPTION
## Summary

This PR updates the Go version from 1.24.4 to 1.25 across the codebase to ensure the project uses the latest stable Go release.

## Changes

- Updated `go.mod` to use Go version 1.25
- Updated `Dockerfile` builder base image to use `golang:1.25`
- Minor indentation fixes in Dockerfile for consistency

## Motivation

Keeping Go version up-to-date provides access to:
- Latest language features and improvements
- Performance enhancements
- Security fixes and bug patches
- Better tooling and compiler optimizations

## Testing

No functional changes are expected as this is a version bump. Existing tests should continue to pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **工作流优化**
  * Go 工具链版本升级至 1.25
  * 构建基础镜像版本升级至 1.25

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->