### PR TITLE
feat(helm): configurable nodeSelector, tolerations and pod fields

### DIFF
--- a/charts/lxcfs-on-kubernetes/README.md
+++ b/charts/lxcfs-on-kubernetes/README.md
@@ -60,6 +60,10 @@ lxcfs:
 | Key                      | Type   | Default                                             | Description |
 |--------------------------|--------|-----------------------------------------------------|-------------|
 | affinity                 | object | `{}`                                                | Affinity to add to the controller Pods |
+| nodeSelector             | object | `{}`                                                | Node selector for the controller Deployment |
+| tolerations              | list   | `[]`                                                | Tolerations for the controller Deployment |
+| podSecurityContext       | object | `{}`                                                | Pod-level security context for the controller |
+| revisionHistoryLimit     | int    | `10`                                                | Number of old ReplicaSets to retain for the Deployment |
 | image.agent              | string | `"ghcr.io/cndoit18/lxcfs-agent:v0.2.1"`            | lxcfs-on-kubernetes agent image |
 | image.manager            | string | `"ghcr.io/cndoit18/lxcfs-manager:v0.2.1"`          | lxcfs-on-kubernetes controller image |
 | imagePullSecrets         | list   | `[]`                                                | Reference to one or more secrets to be used when pulling images. See [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/) |
@@ -72,6 +76,10 @@ lxcfs:
 | lxcfs.matchLabels        | object | `{"mount-lxcfs":"enabled"}`                        | For namespaces that match the labels, the Pods under it will mount lxcfs |
 | lxcfs.mountPath          | string | `"/var/lib/lxcfs-on-k8s/lxcfs"`                    | Specify the mount path of lxcfs on the host |
 | lxcfs.podAnnotations     | object | `{}`                                                | Additional annotations to add to the agent Pods |
+| lxcfs.nodeSelector       | object | `{}`                                                | Node selector for the lxcfs DaemonSet |
+| lxcfs.tolerations        | list   | `[]`                                                | Tolerations for the lxcfs DaemonSet (e.g. to run on tainted nodes) |
+| lxcfs.updateStrategy     | object | `{"type":"RollingUpdate","rollingUpdate":{"maxUnavailable":1}}` | DaemonSet update strategy |
+| lxcfs.podSecurityContext | object | `{}`                                                | Pod-level security context for the lxcfs DaemonSet |
 | lxcfs.resources          | object | `{"limits":{"cpu":"500m","memory":"300Mi"},"requests":{"cpu":"300m","memory":"200M"}}` | Expects input structure as per specification. See [Kubernetes API](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#resourcerequirements-v1-core) |
 | lxcfs.useDaemonset       | bool   | `true`                                              | Installing lxcfs with daemonset |
 | podAnnotations           | object | `{}`                                                | Additional annotations to add to the controller Pods |

--- a/charts/lxcfs-on-kubernetes/templates/daemonset.yaml
+++ b/charts/lxcfs-on-kubernetes/templates/daemonset.yaml
@@ -7,6 +7,7 @@ metadata:
   name: '{{ include "chart.fullname" . }}-controller-manager-daemonset'
   namespace: {{ .Release.Namespace | quote }}
 spec:
+  updateStrategy: {{- toYaml .Values.lxcfs.updateStrategy | nindent 4 }}
   selector:
     matchLabels: {{- include "chart.lxcfs.selectorLabels" . | nindent 6 }}
   template:
@@ -14,6 +15,18 @@ spec:
       annotations: {{- toYaml .Values.lxcfs.podAnnotations | nindent 8 }}
       labels: {{- include "chart.lxcfs.selectorLabels" . | nindent 8 }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.lxcfs.nodeSelector }}
+      nodeSelector: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.lxcfs.tolerations }}
+      tolerations: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.lxcfs.podSecurityContext }}
+      securityContext: {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - args: {{- include "chart.lxcfs.args" . | nindent 8 }}
         image: {{.Values.image.agent}}

--- a/charts/lxcfs-on-kubernetes/templates/deployment.yaml
+++ b/charts/lxcfs-on-kubernetes/templates/deployment.yaml
@@ -7,6 +7,7 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
 spec:
   replicas: {{ .Values.replicas }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   selector:
     matchLabels: {{- include "chart.selectorLabels" . | nindent 6 }}
   template:
@@ -14,6 +15,18 @@ spec:
       annotations: {{- toYaml .Values.podAnnotations | nindent 8 }}
       labels: {{- include "chart.selectorLabels" . | nindent 8 }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext: {{- toYaml . | nindent 8 }}
+      {{- end }}
       affinity: {{ if .Values.affinity }}{{ toYaml .Values.affinity | nindent 8 }}{{ else }}{}{{ end }}
       containers:
       - args:

--- a/charts/lxcfs-on-kubernetes/values.yaml
+++ b/charts/lxcfs-on-kubernetes/values.yaml
@@ -46,7 +46,12 @@ resources:
     cpu: 300m
     memory: 200Mi
 
-# affinity -- Affinity to add to the controller Pods
+# nodeSelector -- Node selector for the controller Deployment
+# <https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector>
+nodeSelector: {}
+
+# affinity -- Affinity for the controller Pods (podAntiAffinity, nodeAffinity, etc.).
+# May be set together with nodeSelector: the scheduler requires all of them to match (AND).
 affinity: {}
 #affinity:
 #  nodeAffinity:
@@ -64,6 +69,18 @@ affinity: {}
 #              app.kubernetes.io/compose: manager
 #          topologyKey: kubernetes.io/hostname
 #        weight: 100
+
+# tolerations -- Tolerations for the controller Deployment
+# <https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/>
+tolerations: []
+
+# podSecurityContext -- Pod-level security context for the controller
+# <https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#podsecuritycontext-v1-core>
+podSecurityContext: {}
+
+# revisionHistoryLimit -- Number of old ReplicaSets to retain in the controller Deployment
+# <https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#revision-history-limit>
+revisionHistoryLimit: 10
 
 # podAnnotations -- Additional annotations to add to the controller Pods
 podAnnotations: {}
@@ -86,6 +103,30 @@ lxcfs:
     requests:
       cpu: 300m
       memory: 200M
+  # lxcfs.nodeSelector -- Node selector for the lxcfs DaemonSet (run only on matching nodes)
+  # <https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector>
+  nodeSelector: {}
+
+  # lxcfs.tolerations -- Tolerations for the lxcfs DaemonSet (e.g. to run on tainted nodes)
+  # <https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/>
+  # Example for a dedicated node pool:
+  # tolerations:
+  #   - key: dedicated
+  #     operator: Equal
+  #     value: lxcfs
+  #     effect: NoSchedule
+  tolerations: []
+
+  # lxcfs.updateStrategy -- Update strategy for the DaemonSet
+  # <https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/#update-strategy>
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+
+  # lxcfs.podSecurityContext -- Pod-level security context for the lxcfs DaemonSet
+  podSecurityContext: {}
+
   # lxcfs.matchLabels -- For namespaces that match the labes, the Pods under it will mount lxcfs.
   matchLabels: 
     mount-lxcfs: enabled


### PR DESCRIPTION
* Expose `nodeSelector` and `tolerations` for the controller Deployment and lxcfs DaemonSet, and optional `podSecurityContext`, `revisionHistoryLimit`, and DaemonSet `updateStrategy`. 
* Wire `imagePullSecrets` - it is in values.yaml, but not in manifests.
* Document values in README and clarify that nodeSelector and affinity combine with AND scheduling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Helm 图表配置选项文档已扩展，涵盖控制器和 LXCFS DaemonSet 的新配置参数。

## New Features
* 为控制器部署添加了节点选择器、容限、Pod 安全上下文和修订历史限制配置。
* 为 LXCFS DaemonSet 新增了节点选择器、容限、更新策略和 Pod 安全上下文配置选项。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->