### PR TITLE
fix(ci): enable image push on tags/master and use correct registry path

### DIFF
--- a/.github/workflows/ci-images.yaml
+++ b/.github/workflows/ci-images.yaml
@@ -51,11 +51,19 @@ jobs:
         with:
           version: latest
 
+      - name: Login to GitHub Container Registry
+        if: ${{ startsWith(github.ref, 'refs/tags/') || github.ref == format('refs/heads/{0}', 'master') }}
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v6
         with:
-          images: ghcr.io/${{ github.repository }}/${{ matrix.image.dockerimage }}
+          images: ghcr.io/${{ github.repository_owner }}/${{ matrix.image.dockerimage }}
           flavor: latest=false
           tags: |
             type=raw,value=canary,enable=${{ github.ref == format('refs/heads/{0}', 'master') }}
@@ -63,13 +71,13 @@ jobs:
             type=semver,pattern={{raw}}
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/') }}
 
-      - name: Build
+      - name: Build and Push
         uses: docker/build-push-action@v7
         with:
           context: .
           file: ${{ matrix.image.dockerfile }}
           platforms: linux/amd64,linux/arm64
-          push: false 
+          push: ${{ startsWith(github.ref, 'refs/tags/') || github.ref == format('refs/heads/{0}', 'master') }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha


### PR DESCRIPTION
Fixes two issues in ci-images workflow:

1. `push: false` was hardcoded — images were never pushed even on tag releases. Now conditionally pushes on `refs/tags/*` and `master`.
2. Image path used `github.repository` (`ghcr.io/cndoit18/lxcfs-on-kubernetes/lxcfs-agent`) instead of `github.repository_owner` (`ghcr.io/cndoit18/lxcfs-agent`), matching the path referenced in goreleaser, helm values, and manifests.
3. Added GHCR login step for authenticated pushes.