### PR TITLE
fix(ci): enable image push on tags/master with GITHUB_TOKEN

### DIFF
--- a/.github/workflows/ci-images.yaml
+++ b/.github/workflows/ci-images.yaml
@@ -63,7 +63,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v6
         with:
-          images: ghcr.io/${{ github.repository_owner }}/${{ matrix.image.dockerimage }}
+          images: ghcr.io/${{ github.repository }}/${{ matrix.image.dockerimage }}
           flavor: latest=false
           tags: |
             type=raw,value=canary,enable=${{ github.ref == format('refs/heads/{0}', 'master') }}


### PR DESCRIPTION
Fixes ci-images workflow so images are actually pushed to GHCR.

Changes from the original `push: false`:
1. **Conditional push**: images push on `refs/tags/*` and `master`, PR builds only.
2. **GHCR login**: uses default `GITHUB_TOKEN` (no extra secrets needed).
3. **Image path**: `ghcr.io/${{ github.repository }}/lxcfs-agent` — auto-linked to repo, `GITHUB_TOKEN` has write permission.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 调整容器镜像发布路径，现使用完整仓库标识生成 GitHub Container Registry（GHCR）镜像地址。
  * 后续构建镜像将推送至更新后的路径前缀。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->