### PR TITLE
fix(docker): bundle libm.so.6 in agent image

### DIFF
--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -48,6 +48,7 @@ RUN ARCH="$(uname -m)"; \
 	cp "/lib/$ARCH-linux-gnu/libgcc_s.so.1" "lib/$ARCH-linux-gnu/"; \
 	cp "/lib/$ARCH-linux-gnu/libpthread.so.0" "lib/$ARCH-linux-gnu/"; \
 	cp "/lib/$ARCH-linux-gnu/libc.so.6" "lib/$ARCH-linux-gnu/"; \
+	cp "/lib/$ARCH-linux-gnu/libm.so.6" "lib/$ARCH-linux-gnu/"; \
 	if [ "$ARCH" = "aarch64" ]; then \
 	cp "/lib/$ARCH-linux-gnu/ld-linux-aarch64.so.1" "lib/ld-linux-aarch64.so.1"; \
 	else \


### PR DESCRIPTION
## Problem

`lxcfs` fails to start at runtime with:

```
libm.so.6: cannot open shared object file: No such file or directory
Failed to open liblxcfs.so at /usr/lib/x86_64-linux-gnu/lxcfs/liblxcfs.so
```

## Root cause

`Dockerfile.agent` builds lxcfs 7.0.0 on Ubuntu Noble (glibc) and copies the binary plus its dependent shared libraries into an Alpine final image. The copy list was missing `libm.so.6`, which `liblxcfs.so` links against. When `lxcfs` `dlopen`s `liblxcfs.so` on Alpine, the missing transitive `libm.so.6` dependency causes the failure above.

## Fix

Add `libm.so.6` to the list of shared libraries copied from the builder stage into the rootfs.