### PR TITLE
feat(admission): mount /proc/pressure and /proc/slabinfo

### DIFF
--- a/pkg/admission/mutate.go
+++ b/pkg/admission/mutate.go
@@ -119,6 +119,8 @@ func (m *mutate) ensureVolumeMount(volumeMounts []corev1.VolumeMount) []corev1.V
 		"lxcfs-proc-swaps":             "/proc/swaps",
 		"lxcfs-proc-uptime":            "/proc/uptime",
 		"lxcfs-proc-loadavg":           "/proc/loadavg",
+		"lxcfs-proc-pressure":          "/proc/pressure",
+		"lxcfs-proc-slabinfo":          "/proc/slabinfo",
 		"lxcfs-sys-devices-system-cpu": "/sys/devices/system/cpu",
 		"lxcfs-root-parent-dir":        filepath.Dir(strings.TrimRight(m.mutatePath, "/")),
 	}
@@ -192,6 +194,16 @@ func (m *mutate) ensureVolume(vs []corev1.Volume) []corev1.Volume {
 		"lxcfs-proc-loadavg": {
 			HostPath: &corev1.HostPathVolumeSource{
 				Path: m.mutatePath + "proc/loadavg",
+			},
+		},
+		"lxcfs-proc-pressure": {
+			HostPath: &corev1.HostPathVolumeSource{
+				Path: m.mutatePath + "proc/pressure",
+			},
+		},
+		"lxcfs-proc-slabinfo": {
+			HostPath: &corev1.HostPathVolumeSource{
+				Path: m.mutatePath + "proc/slabinfo",
 			},
 		},
 		"lxcfs-sys-devices-system-cpu": {

--- a/scripts/lxcfs-remount.sh
+++ b/scripts/lxcfs-remount.sh
@@ -19,13 +19,15 @@ for container in $containers; do
         echo "remount $container"
         PID=$(crictl inspect --output go-template --template '{{- .info.pid -}}' $container)
         # mount /proc
-        for file in meminfo cpuinfo loadavg stat diskstats swaps uptime; do
+        for file in meminfo cpuinfo loadavg stat diskstats swaps uptime slabinfo; do
             echo nsenter --target $PID --mount -- mount -o bind "$LXCFS/proc/$file" "/proc/$file"
             nsenter --target $PID --mount -- mount -o bind "$LXCFS/proc/$file" "/proc/$file"
         done
 
         echo nsenter --target $PID --mount -- mount -o bind "$LXCFS/sys/devices/system/cpu" "/sys/devices/system/cpu"
         nsenter --target $PID --mount -- mount -o bind "$LXCFS/sys/devices/system/cpu" "/sys/devices/system/cpu"
+        echo nsenter --target $PID --mount -- mount -o bind "$LXCFS/proc/pressure" "/proc/pressure"
+        nsenter --target $PID --mount -- mount -o bind "$LXCFS/proc/pressure" "/proc/pressure"
     else
         echo "No LXCFS mount found for container $container"
     fi


### PR DESCRIPTION
## What

lxcfs v7.0.0 virtualizes PSI (Pressure Stall Information) files and `/proc/slabinfo`, but the webhook never injected mounts for them. This PR closes that gap.

## Changes

**`pkg/admission/mutate.go`** — added two entries to both `ensureVolumeMount` and `ensureVolume`:

| Volume | Mount path | Type |
|---|---|---|
| `lxcfs-proc-pressure` | `/proc/pressure` | directory bind — covers `io`, `cpu`, `memory` PSI in a single mount (analogous to how `/sys/devices/system/cpu` is mounted) |
| `lxcfs-proc-slabinfo` | `/proc/slabinfo` | single file |

**`scripts/lxcfs-remount.sh`** — added `slabinfo` to the proc-file remount loop and a `/proc/pressure` remount so the new mounts survive an lxcfs restart.

## Why it matters

PSI gives containers accurate per-cgroup resource pressure data. Without these mounts, monitoring tools (node-exporter, Prometheus, Datadog …) and HPA autoscaling read host-global values or fail silently, defeating the isolation lxcfs provides.

> Note: PSI requires cgroup v2 with `CONFIG_PSI=y`. On cgroup v1 these files may be unavailable — the bind mount will simply expose whatever lxcfs provides (or nothing), with no crash.

## Verification

- `go build ./...` ✓
- `go vet ./...` ✓
- `go test ./...` ✓
- `gofmt -l` on the Go file ✓

Reference: [lxcfs v7.0.0 README](https://github.com/lxc/lxcfs/blob/v7.0.0/README.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 增加对 `/proc/pressure` 和 `/proc/slabinfo` 的 LXCFS 挂载支持。
  * 容器可获取更完整的压力指标和内核 slab 分配信息。

* **改进**
  * LXCFS 重新挂载流程现会自动处理新增的伪文件系统内容。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->