### PR TITLE
docs: remove cert-manager prerequisite

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ running.
 ## Prerequisites
 
 1. `Kubernetes` cluster (v1.19+) is running. For local development purpose, check [Kind installation](https://kind.sigs.k8s.io/docs/user/quick-start/#installation).
-1. `cert-manager` (v1.2+) is [installed](https://cert-manager.io/docs/installation/kubernetes/).
 
 you can enable the namespace for injection.
 


### PR DESCRIPTION
The chart now self-signs the webhook certificate via Helm `genCA`/`genSignedCert` (see `templates/mutatingwebhookconfiguration.yaml`), so `cert-manager` is no longer a runtime dependency.

## Change
- Remove the `cert-manager (v1.2+) is installed` line from `Prerequisites` in `README.md`