### PR TITLE
fix(chart): self-heal stale lxcfs FUSE mount on agent restart

### DIFF
--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -58,6 +58,10 @@ RUN ARCH="$(uname -m)"; \
 # alpine:3.22.0 (use tag so buildx can resolve the correct multi-arch manifest)
 FROM alpine:3.22.0
 
+# nsenter is part of util-linux, not busybox; needed by the DaemonSet
+# initContainer and by lxcfs-remount.sh to operate in the host mount ns.
+RUN apk add --no-cache util-linux-misc
+
 COPY --from=builder /rootfs/ /
 COPY --from=builder /opt/tools/crictl /usr/local/bin/crictl
 COPY scripts/lxcfs-remount.sh /usr/local/bin/lxcfs-remount.sh

--- a/charts/lxcfs-on-kubernetes/templates/daemonset.yaml
+++ b/charts/lxcfs-on-kubernetes/templates/daemonset.yaml
@@ -14,6 +14,20 @@ spec:
       annotations: {{- toYaml .Values.lxcfs.podAnnotations | nindent 8 }}
       labels: {{- include "chart.lxcfs.selectorLabels" . | nindent 8 }}
     spec:
+      initContainers:
+      - name: cleanup-stale-lxcfs
+        image: {{.Values.image.agent}}
+        imagePullPolicy: {{ .Values.pullPolicy | quote }}
+        command:
+        - sh
+        - -c
+        - |
+          set -x
+          M={{ trimSuffix "/" .Values.lxcfs.mountPath | quote }}
+          nsenter -t 1 -m -- umount -l "$M" 2>/dev/null || true
+          nsenter -t 1 -m -- mkdir -p "$M"
+        securityContext:
+          privileged: true
       containers:
       - args: {{- include "chart.lxcfs.args" . | nindent 8 }}
         image: {{.Values.image.agent}}
@@ -51,7 +65,6 @@ spec:
           name: lxcfs-crictl-config
       - hostPath:
           path: {{.Values.lxcfs.mountPath}}
-          type: DirectoryOrCreate
         name: lxcfs
       - hostPath:
           path: /sys/fs/cgroup

--- a/charts/lxcfs-on-kubernetes/templates/daemonset.yaml
+++ b/charts/lxcfs-on-kubernetes/templates/daemonset.yaml
@@ -22,10 +22,12 @@ spec:
         - sh
         - -c
         - |
-          set -x
+          set -eux
           M={{ trimSuffix "/" .Values.lxcfs.mountPath | quote }}
-          nsenter -t 1 -m -- umount -l "$M" 2>/dev/null || true
-          nsenter -t 1 -m -- mkdir -p "$M"
+          if nsenter -t 1 -m -- mountpoint -q -- "$M"; then
+            nsenter -t 1 -m -- umount -l -- "$M"
+          fi
+          nsenter -t 1 -m -- mkdir -p -- "$M"
         securityContext:
           privileged: true
       containers:


### PR DESCRIPTION
## Problem

After the lxcfs agent pod restarts/crashes, the FUSE mountpoint becomes stale and pods fail to start:

```
failed to generate container "..." spec: failed to generate spec:
failed to stat "/var/lib/lxcfs-on-k8s/lxcfs": stat /var/lib/lxcfs-on-k8s/lxcfs:
transport endpoint is not connected
```

## Root cause

lxcfs is a FUSE filesystem. When the lxcfs process dies, the kernel mount entry stays but any access returns `ENOTCONN`. Two distinct breakages:

1. **Workload pods** (newly created): the webhook injects lxcfs bind mounts with **no `Type`** (`HostPathUnset`), so kubelet's volume `SetUp` is a no-op (returns at `host_path.go:250`) and passes — but the runtime stats the source path during spec generation and fails on the stale path. This is the error users see.

2. **Agent pod recreated** (new pod UID, e.g. DaemonSet rollout, evict/reschedule): its lxcfs hostPath was `type: DirectoryOrCreate`, so `SetUp` runs `checkType → MakeDir → os.MkdirAll`, which `stat`s the stale path and fails → new agent pod stuck in `ContainerCreating`, and the initContainer never gets to run.

Note: plain **container restart within the same pod** self-heals today, so it needs no fix: volumes are set up only once per pod lifetime (the per-container bind of the already-prepared pod volume doesn't re-`stat` the host path), and the restarted `lxcfs` simply stacks a fresh FUSE mount over the stale mountpoint, which propagates back to the host through the volume's `Bidirectional` mount propagation. initContainers don't re-run on container restart anyway — this fix targets the rarer pod-recreation case (new pod UID), which is the dangerous one.

## Fix

In `templates/daemonset.yaml`:

- **Drop `type: DirectoryOrCreate`** from the agent lxcfs hostPath → `SetUp` becomes a no-op (`HostPathUnset`), so it never `stat`s/mkdirs the stale path. This aligns the agent volume with how the webhook already injects lxcfs volumes into workload pods (proven, type-less).
- **Add an `cleanup-stale-lxcfs` initContainer** (privileged; pod already has `hostPID: true`). It does **not** mount the lxcfs path (so its own spec-gen never touches the stale path); instead it enters the host mount namespace via `nsenter -t 1 -m` to:
  - `umount -l "$M"` — lazy-unmount the stale FUSE mountpoint (works without a live FUSE fd);
  - `mkdir -p "$M"` — take over the directory-creation role previously done by `DirectoryOrCreate`. Only `$M` is needed; `proc/` and `sys/` are virtualized by lxcfs once it mounts.

## Startup order (verified)

Volume `SetUp` (zero IO) → initContainer cleans stale + ensures mountpoint exists → main agent container stats `$M` (now a clean dir) → `lxcfs ... $M` mounts fresh FUSE → workload pods created afterwards succeed.

Rendered with `helm template` against default values.

Signed-off-by: yxxhero <aiopsclub@163.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug 修复**
  * 优化 Kubernetes 环境下 lxcfs 挂载点的清理流程，避免过期挂载影响服务启动。
  * 在挂载路径不存在时自动创建所需目录，提升部署稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
